### PR TITLE
Resolve template

### DIFF
--- a/__tests__/resolve-template.test.js
+++ b/__tests__/resolve-template.test.js
@@ -1,0 +1,13 @@
+const { resolveTemplate } = require('../src/util')
+const ds = {
+  record: {
+    get: Promise.resolve({ value: 'test' })
+  }
+}
+
+test('replaces strings', async () => {
+  expect(await resolveTemplate('{{test}}', { test: '111' }, { ds })).toBe('111')
+  expect(await resolveTemplate('pre{{test}}post', { test: '111' }, { ds })).toBe('pre111post')
+  expect(await resolveTemplate('123{{test}}456{{test}}{{test}}', { test: 'body' }, { ds })).toBe('123body456bodybody')
+  expect(await resolveTemplate('test{{test.foo}}test{{test.bar.baz}}test', { test: { foo: '111', bar: { baz: '222' } } }, { ds })).toBe('test111test222test')
+})

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "balanced-match": "^1.0.0",
     "http-errors": "^1.7.1",
     "merge-ranges": "^1.0.2",
+    "moment": "^2.23.0",
     "statuses": "^1.5.0",
     "xuid": "^3.0.2"
   },

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   cached: require('./cached'),
   applyMatches: require('./apply-matches'),
-  compareRev: require('./compare-rev')
+  compareRev: require('./compare-rev'),
+  resolveTemplate: require('./resolve-template')
 }

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -1,8 +1,7 @@
 const balanced = require('balanced-match')
 const moment = require('moment')
 
-module.exports = async function resolveTemplate (template, resolver) {
-  const { map, ds } = resolver
+module.exports = async function resolveTemplate (template, context, { ds }) {
   let response = ''
   const match = balanced('{{', '}}', template)
   if (!match) {
@@ -10,14 +9,14 @@ module.exports = async function resolveTemplate (template, resolver) {
   }
   var { pre, body, post } = match
   response += pre
-  response += await parseExpression(body, map, ds)
+  response += await parseExpression(body, context, { ds })
   if (post) {
-    response += await resolveTemplate(post, { map, ds })
+    response += await resolveTemplate(post, context, { ds })
   }
   return response
 }
 
-async function parseExpression (expression, context, ds) {
+async function parseExpression (expression, context, { ds }) {
   const parts = expression.split('|')
   const baseValuePath = parts.shift().trim()
   const baseValue = getProperty(context, baseValuePath)

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -1,41 +1,22 @@
-const fp = require('lodash/fp')
 const balanced = require('balanced-match')
 
-module.exports = async function resolveTemplate (str, resolver) {
-  if (fp.isPlainObject(resolver)) {
-    const { map, ds } = resolver
-
-    resolver = async key => {
-      if (!fp.isString(key)) {
-        return ''
-      }
-
-      // {id}:{domain},{path}
-      const [ , id, path ] = key.match(/^\s*([^:\s]+:[^,\s]+)(?:\s*,\s*([^\s]+))?\s*$/) || []
-
-      let val
-      if (id) {
-        val = ds ? await ds.record.get(id, path) : null
-      } else {
-        val = map ? fp.get(key, map) : null
-      }
-
-      return val != null ? String(val) : ''
-    }
+module.exports = async function resolveTemplate (template, context) {
+  let response = ''
+  const match = balanced('{{', '}}', template)
+  if (!match) {
+    return template
   }
-
-  let res = ''
-  while (true) {
-    const match = balanced('${', '}', str)
-
-    if (!match) {
-      return res + str
-    }
-
-    const { pre, body, post } = match
-
-    res += pre
-    res += await resolver(await resolveTemplate(body, resolver))
-    str = post
+  var { pre, body, post } = match
+  response += pre
+  response += getProperty(context, body)
+  if (post) {
+    response += await resolveTemplate(post, context)
   }
+  return response
+}
+
+function getProperty (obj, desc) {
+  var arr = desc.split('.')
+  while (arr.length && (obj = obj[arr.shift()]));
+  return obj
 }

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -16,9 +16,8 @@ module.exports = async function resolveTemplate (template, context, { ds }) {
 }
 
 async function parseExpression (expression, context, { ds }) {
-  const parts = expression.split('|')
-  const baseValuePath = parts.shift().trim()
-  const baseValue = getProperty(context, baseValuePath)
+  const parts = expression.split(/\s*\|\s*/)
+  const baseValue = getProperty(context, parts.shift())
 
   return parts.reduce(await applyFilter(ds), Promise.resolve(baseValue))
 }
@@ -30,9 +29,8 @@ function getProperty (obj, desc) {
 }
 
 function applyFilter (ds) {
-  return async (valuePromise, rawFilter) => {
+  return async (valuePromise, filter) => {
     const value = await valuePromise
-    const filter = rawFilter.trim()
     const regExp = /\('([^)]+)'\)/
     const filterValueArr = regExp.exec(filter)
     const filterValue = filterValueArr && filterValueArr[1]

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -1,6 +1,8 @@
 const balanced = require('balanced-match')
+const moment = require('moment')
 
-module.exports = async function resolveTemplate (template, context) {
+module.exports = async function resolveTemplate (template, resolver) {
+  const { map, ds } = resolver
   let response = ''
   const match = balanced('{{', '}}', template)
   if (!match) {
@@ -8,15 +10,45 @@ module.exports = async function resolveTemplate (template, context) {
   }
   var { pre, body, post } = match
   response += pre
-  response += getProperty(context, body)
+  response += await parseExpression(body, map, ds)
   if (post) {
-    response += await resolveTemplate(post, context)
+    response += await resolveTemplate(post, { map, ds })
   }
   return response
+}
+
+async function parseExpression (expression, context, ds) {
+  const parts = expression.split('|')
+  const baseValuePath = parts.shift().trim()
+  const baseValue = getProperty(context, baseValuePath)
+
+  return parts.reduce(await applyFilter(ds), Promise.resolve(baseValue))
 }
 
 function getProperty (obj, desc) {
   var arr = desc.split('.')
   while (arr.length && (obj = obj[arr.shift()]));
   return obj
+}
+
+function applyFilter (ds) {
+  return async (valuePromise, rawFilter) => {
+    const value = await valuePromise
+    const filter = rawFilter.trim()
+    const regExp = /\('([^)]+)'\)/
+    const filterValueArr = regExp.exec(filter)
+    const filterValue = filterValueArr && filterValueArr[1]
+
+    if (/^moment\(/.test(filter)) {
+      return moment(value).format(filterValue)
+    } else if (/^append\(/.test(filter)) {
+      return value + filterValue
+    } else if (/^pluck\(/.test(filter)) {
+      return value[filterValue]
+    } else if (/^join\(/.test(filter)) {
+      return value.join(filterValue)
+    } else if (/^ds/.test(filter)) {
+      return ds.record.get(value)
+    }
+  }
 }

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -7,7 +7,7 @@ module.exports = async function resolveTemplate (template, context, { ds }) {
   if (!match) {
     return template
   }
-  var { pre, body, post } = match
+  const { pre, body, post } = match
   response += pre
   response += await parseExpression(body, context, { ds })
   if (post) {
@@ -25,7 +25,7 @@ async function parseExpression (expression, context, { ds }) {
 }
 
 function getProperty (obj, desc) {
-  var arr = desc.split('.')
+  const arr = desc.split('.')
   while (arr.length && (obj = obj[arr.shift()]));
   return obj
 }

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -2,18 +2,17 @@ const balanced = require('balanced-match')
 const moment = require('moment')
 
 module.exports = async function resolveTemplate (template, context, { ds }) {
-  let response = ''
-  const match = balanced('{{', '}}', template)
-  if (!match) {
-    return template
+  let response = template
+  let match = false
+  while (true) {
+    match = balanced('{{', '}}', response)
+    if (!match) {
+      return response
+    }
+    const { pre, body, post } = match
+    const value = await parseExpression(body, context, { ds })
+    response = `${pre}${value}${post}`
   }
-  const { pre, body, post } = match
-  response += pre
-  response += await parseExpression(body, context, { ds })
-  if (post) {
-    response += await resolveTemplate(post, context, { ds })
-  }
-  return response
 }
 
 async function parseExpression (expression, context, { ds }) {


### PR DESCRIPTION
## What does it do?
Enables simple property inclusion and use of filters in template via `resolveTemplate` function.

## Risks or dependencies?
Backwards compatibility with old `resolveTemplate` function is not guaranteed.

## How to test?
Import `src/util/resolve-template.js` and run with template and context like this `await resolveTemplate('{{foo.id}}', context, { ds })`.

Refs: #2677