### PR TITLE
resolve-template improvements

### DIFF
--- a/__tests__/resolve-template.test.js
+++ b/__tests__/resolve-template.test.js
@@ -48,9 +48,9 @@ describe('select', () => {
     expect(await resolveTemplate(`{{ test | select() }}`, { test: [ 1 ] })).toMatchObject([ 1 ])
   })
   test('filters arrays', async () => {
-    expect(await resolveTemplate(`{{ test | select('gte', 2) }}`, { test: [ 1, 2 ] })).toMatchObject([ 2 ])
+    expect(await resolveTemplate(`{{ test | select('ge', 2) }}`, { test: [ 1, 2 ] })).toMatchObject([ 2 ])
   })
   test('filters objects', async () => {
-    expect(await resolveTemplate(`{{ test | select('gte', 2) }}`, { test: { a: 1, b: 2 } })).toMatchObject({ b: 2 })
+    expect(await resolveTemplate(`{{ test | select('ge', 2) }}`, { test: { a: 1, b: 2 } })).toMatchObject({ b: 2 })
   })
 })

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -68,10 +68,10 @@ function onParseExpression (expression, context, options) {
         : (value == null ? defaultValue : value)
     ),
     // number
+    le: (x) => value => Observable.of(value <= x),
     lt: (x) => value => Observable.of(value < x),
-    lte: (x) => value => Observable.of(value <= x),
+    ge: (x) => value => Observable.of(value >= x),
     gt: (x) => value => Observable.of(value > x),
-    gte: (x) => value => Observable.of(value >= x),
     int: (fallback, radix) => value => Observable.of(parseInt(value, radix) || fallback),
     float: (fallback) => value => Observable.of(parseFloat(value) || fallback),
     mul: (x) => value => Observable.of(x * value),

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -56,14 +56,17 @@ function onParseExpression (expression, context, options) {
 
   // DOCS inspiration; http://jinja.pocoo.org/docs/2.10/templates/#builtin-filters
   const FILTERS = {
-    // undefined
-    default: (fallback) => value => Observable.of(value === undefined ? fallback : value),
     // any
     boolean: () => value => Observable.of(Boolean(value)),
     string: () => value => Observable.of(String(value)),
     array: () => value => Observable.of([ value ]),
     tojson: (indent) => value => Observable.of(JSON.stringify(value, null, indent)),
     fromjson: () => value => Observable.of(JSON6.parse(value)),
+    default: (defaultValue, notJustNully) => value => Observable.of(
+      notJustNully
+        ? (!value ? defaultValue : value)
+        : (value == null ? defaultValue : value)
+    ),
     // number
     lt: (x) => value => Observable.of(value < x),
     lte: (x) => value => Observable.of(value <= x),

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -73,7 +73,7 @@ function onParseExpression (expression, context, options) {
     ne: (x) => value => Observable.of(value !== x),
     isArray: () => value => Observable.of(Array.isArray(value)),
     isEqual: (x) => value => Observable.of(isEqual(value, x)),
-    isNully: () => value => Observable.of(value == null),
+    isNil: () => value => Observable.of(value == null),
     isNumber: () => value => Observable.of(Number.isFinite(value)),
     isString: () => value => Observable.of(isString(value)),
     // number

--- a/src/util/resolve-template.js
+++ b/src/util/resolve-template.js
@@ -4,7 +4,9 @@ const rx = require('rxjs/operators')
 const Observable = require('rxjs')
 const JSON6 = require('json-6')
 const get = require('lodash/get')
+const isEqual = require('lodash/isEqual')
 const isPlainObject = require('lodash/isPlainObject')
+const isString = require('lodash/isString')
 const fromPairs = require('lodash/fromPairs')
 const flatten = require('lodash/fp/flatten')
 const capitalize = require('lodash/capitalize')
@@ -67,6 +69,13 @@ function onParseExpression (expression, context, options) {
         ? (!value ? defaultValue : value)
         : (value == null ? defaultValue : value)
     ),
+    eq: (x) => value => Observable.of(value === x),
+    ne: (x) => value => Observable.of(value !== x),
+    isArray: () => value => Observable.of(Array.isArray(value)),
+    isEqual: (x) => value => Observable.of(isEqual(value, x)),
+    isNully: () => value => Observable.of(value == null),
+    isNumber: () => value => Observable.of(Number.isFinite(value)),
+    isString: () => value => Observable.of(isString(value)),
     // number
     le: (x) => value => Observable.of(value <= x),
     lt: (x) => value => Observable.of(value < x),


### PR DESCRIPTION
# What

- `default` filter friendlier + more like jinja
- rename `>=` and `<=` tests to `ge` and `le` to match jinja
- add some more test filters
	- `eq` (strict) - jinja name
    - `ne` (strict) - jinja name
    - `isArray` - lodash name
    - `isEqual` (deep) - lodash name
    - `isNully` - lodash name
    - `isNumber` - lodash name
    - `isString` - lodash name

# Risk

very low, but please CR proper

# Deps

none

# Test?

ask, probably needs interactive questions/answers session

Refs: https://github.com/nxtedition/nxt/issues/2830