### PR TITLE
fix(resolve-template): avoid quoted commas while splitting arguments

### DIFF
--- a/__tests__/resolve-template.test.js
+++ b/__tests__/resolve-template.test.js
@@ -44,4 +44,6 @@ test('ds', async () => {
 test('replace array', async () => {
   expect(await resolveTemplate(`{{test | join("#") | replace("foo", "bar") | split("#")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
   expect(await resolveTemplate(`{{test | join(",") | replace("foo", "bar") | split(",")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
+  expect(await resolveTemplate(`{{test | join(',') | replace("foo", "bar") | split(",")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
+  expect(await resolveTemplate('{{test | join(`,`) | replace("foo", "bar") | split(",")}}', { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
 })

--- a/__tests__/resolve-template.test.js
+++ b/__tests__/resolve-template.test.js
@@ -43,6 +43,5 @@ test('ds', async () => {
 
 test('replace array', async () => {
   expect(await resolveTemplate(`{{test | join("#") | replace("foo", "bar") | split("#")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
-  // TODO (fix): This fails...
-  // expect(await resolveTemplate(`{{test | join(",") | replace("foo", "bar") | split(",")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
+  expect(await resolveTemplate(`{{test | join(",") | replace("foo", "bar") | split(",")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
 })

--- a/__tests__/resolve-template.test.js
+++ b/__tests__/resolve-template.test.js
@@ -45,5 +45,4 @@ test('replace array', async () => {
   expect(await resolveTemplate(`{{test | join("#") | replace("foo", "bar") | split("#")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
   expect(await resolveTemplate(`{{test | join(",") | replace("foo", "bar") | split(",")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
   expect(await resolveTemplate(`{{test | join(',') | replace("foo", "bar") | split(",")}}`, { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
-  expect(await resolveTemplate('{{test | join(`,`) | replace("foo", "bar") | split(",")}}', { test: ['foo', 'bar'] })).toEqual(['bar', 'bar'])
 })

--- a/src/util/template/expression.js
+++ b/src/util/template/expression.js
@@ -247,13 +247,13 @@ module.exports = ({ ds } = {}) => {
     const [ , filterName, argsStr ] = filterStr.match(/([^(]+)\((.*)\)/) || []
 
     const tokens = argsStr
-      ? argsStr.match(/(".*?"|[^",\s]+)(?=\s*,|\s*$)/g)
+      ? argsStr.match(/(["`'].*?["`']|[^["`'],\s]+)(?=\s*,|\s*$)/g)
       : []
 
     const args = tokens
       .map(x => {
         try {
-          return x ? JSON5.parse(x) : x
+          return x ? JSON5.parse(x.replace(/^`(.*)`$/, '\'$1\'')) : x
         } catch (err) {
           throw new NestedError(`failed to parse token ${x}`, err)
         }

--- a/src/util/template/expression.js
+++ b/src/util/template/expression.js
@@ -247,7 +247,7 @@ module.exports = ({ ds } = {}) => {
     const [ , filterName, argsStr ] = filterStr.match(/([^(]+)\((.*)\)/) || []
 
     const tokens = argsStr
-      ? argsStr.split(/\s*,\s*/)
+      ? argsStr.match(/(".*?"|[^",\s]+)(?=\s*,|\s*$)/g)
       : []
 
     const args = tokens

--- a/src/util/template/expression.js
+++ b/src/util/template/expression.js
@@ -247,7 +247,7 @@ module.exports = ({ ds } = {}) => {
     const [ , filterName, argsStr ] = filterStr.match(/([^(]+)\((.*)\)/) || []
 
     const tokens = argsStr
-      ? argsStr.match(/(["`'].*?["`']|[^["`'],\s]+)(?=\s*,|\s*$)/g)
+      ? argsStr.match(/(["`'].*?["`']|[^"`',\s]+)(?=\s*,|\s*$)/g)
       : []
 
     const args = tokens

--- a/src/util/template/expression.js
+++ b/src/util/template/expression.js
@@ -247,13 +247,13 @@ module.exports = ({ ds } = {}) => {
     const [ , filterName, argsStr ] = filterStr.match(/([^(]+)\((.*)\)/) || []
 
     const tokens = argsStr
-      ? argsStr.match(/(["`'].*?["`']|[^"`',\s]+)(?=\s*,|\s*$)/g)
+      ? argsStr.match(/(["'].*?["']|[^"',\s]+)(?=\s*,|\s*$)/g)
       : []
 
     const args = tokens
       .map(x => {
         try {
-          return x ? JSON5.parse(x.replace(/^`(.*)`$/, '\'$1\'')) : x
+          return x ? JSON5.parse(x) : x
         } catch (err) {
           throw new NestedError(`failed to parse token ${x}`, err)
         }


### PR DESCRIPTION
https://github.com/nxtedition/nxt/issues/3257