### PR TITLE
fix: correct peer dependency version specifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "xuid": "^3.0.2"
   },
   "peerDependencies": {
-    "pino": "^5.6.2",
-    "pino-pretty": "^2.2.1",
-    "rxjs": "^6.3.3"
+    "pino": ">=5.6.2",
+    "pino-pretty": ">=2.2.1",
+    "rxjs": ">=6.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
   "peerDependencies": {
     "pino": ">=5.6.2",
     "pino-pretty": ">=2.2.1",
-    "rxjs": ">=6.3.3"
+    "rxjs": ">=5.x"
   }
 }


### PR DESCRIPTION
You may verify the behaviour at https://semver.npmjs.com/