### PR TITLE
fix(resolve-template): escape newline

### DIFF
--- a/__tests__/resolve-template.test.js
+++ b/__tests__/resolve-template.test.js
@@ -33,6 +33,8 @@ test('replaces strings', async () => {
   expect(await resolveTemplate('123{{test}}456{{test}}{{test}}', { test: 'body' })).toBe('123body456bodybody')
   expect(await resolveTemplate('test{{test.foo}}test{{test.bar.baz}}test', { test: { foo: '111', bar: { baz: '222' } } })).toBe('test111test222test')
   expect(await resolveTemplate('{{ asd | default("te | st")}}', {})).toBe('te | st')
+  expect(await resolveTemplate('{{ asd | default("test\n") }}', {})).toBe('test\n')
+  expect(await resolveTemplate('{{ asd | default("test\n\n") }}', {})).toBe('test\n\n')
 })
 
 test('nested', async () => {

--- a/src/util/template/expression.js
+++ b/src/util/template/expression.js
@@ -335,7 +335,9 @@ module.exports = ({ ds } = {}) => {
   }
 
   const getFilter = memoize((filterStr) => {
-    const [, filterName, argsStr] = filterStr.match(/([^(]+)\((.*)\)/) || []
+    const [, filterName, argsStr] = filterStr
+      .replace(/\n/g, '\\n')
+      .match(/([^(]+)\((.*)\)/) || []
 
     const tokens = split(argsStr, {
       separator: ',',


### PR DESCRIPTION
Properly handles new line characters in templates.