### PR TITLE
feat(yarn): Helper for package version assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "validate-commit-msg": "^2.14.0"
   },
   "dependencies": {
+    "@yarnpkg/lockfile": "^1.1.0",
     "hasha": "^4.0.1",
     "http-errors": "^1.7.3",
     "json5": "^2.1.0",
@@ -75,6 +76,7 @@
     "nested-error-stacks": "^2.1.0",
     "object-hash": "^1.3.1",
     "once": "^1.4.0",
+    "semver": "^7.1.2",
     "split-string": "^6.0.0",
     "statuses": "^1.5.0",
     "xuid": "^3.0.2"

--- a/src/assert-pkg-version.js
+++ b/src/assert-pkg-version.js
@@ -1,0 +1,50 @@
+const lockfile = require('@yarnpkg/lockfile')
+const semver = require('semver')
+const fs = require('fs')
+const fp = require('lodash/fp')
+
+// Usage:
+// ensurePackageVersion('./yarn.lock', {
+//   '@yarnpkg/lockfile': '1.x',
+//   'semver': '>=7',
+// })
+
+module.exports = function ensurePackageVersion (lockfilePath, assertions) {
+  const contents = fs.readFileSync(lockfilePath, { encoding: 'utf8' })
+  const parsed = lockfile.parse(contents)
+  const { type, object } = parsed
+
+  if (type !== 'success') {
+    const error = new Error('error parsing lockfile')
+    error.parsed = parsed
+    throw error
+  }
+
+  const versions = fp.pipe(
+    fp.toPairs,
+    fp.map(([name, info]) => [
+      name.slice(0, name.lastIndexOf('@')),
+      info.version
+    ]),
+    fp.fromPairs
+  )(object)
+
+  for (const [name, condition] of Object.entries(assertions)) {
+    const version = versions[name]
+
+    if (!version) {
+      const error = new Error('missing package')
+      error.packageName = name
+      error.expected = condition
+      throw error
+    }
+
+    if (!semver.satisfies(version, condition)) {
+      const error = new Error('wrong package version')
+      error.packageName = name
+      error.packageVersion = version
+      error.expected = condition
+      throw error
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,11 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -4422,6 +4427,11 @@ semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.2.tgz#847bae5bce68c5d08889824f02667199b70e3d87"
+  integrity sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The use case is that we want to freeze some packages to specific versions. A comment in `package.json` would be best, but sadly not supported. As an alternative, we can use this to add assertions in `config.js`. It works by parsing `yarn.lock` using the official package (https://www.npmjs.com/package/@yarnpkg/lockfile) then checking the versions using `semver.satisfies()` (https://www.npmjs.com/package/semver).